### PR TITLE
improve health endpoint info

### DIFF
--- a/cmd/route-finder/commands/root.go
+++ b/cmd/route-finder/commands/root.go
@@ -39,6 +39,7 @@ var (
 	testing     bool
 	dmsgDisc    string
 	sk          cipher.SecKey
+	dmsgPort    uint16
 )
 
 func init() {
@@ -52,6 +53,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis\033[0m")
 	rootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", "http://dmsgd.skywire.skycoin.com", "url of dmsg-discovery\033[0m")
 	rootCmd.Flags().Var(&sk, "sk", "dmsg secret key\r")
+	rootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\r")
 	var helpflag bool
 	rootCmd.SetUsageTemplate(help)
 	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
@@ -125,8 +127,13 @@ var rootCmd = &cobra.Command{
 
 		metricsutil.ServeHTTPMetrics(logger, metricsAddr)
 
+		var dmsgAddr string
+		if !pk.Null() {
+			dmsgAddr = fmt.Sprintf("%s:%d", pk.Hex(), dmsgPort)
+		}
+
 		enableMetrics := metricsAddr != ""
-		rfAPI := api.New(transportStore, logger, enableMetrics)
+		rfAPI := api.New(transportStore, logger, enableMetrics, dmsgAddr)
 
 		if logger != nil {
 			logger.Infof("Listening on %s", addr)

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -49,6 +49,7 @@ var (
 	testing       bool
 	dmsgDisc      string
 	sk            cipher.SecKey
+	dmsgPort      uint16
 )
 
 func init() {
@@ -64,6 +65,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis\033[0m")
 	rootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", "http://dmsgd.skywire.skycoin.com", "url of dmsg-discovery\033[0m")
 	rootCmd.Flags().Var(&sk, "sk", "dmsg secret key\r")
+	rootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\r")
 	var helpflag bool
 	rootCmd.SetUsageTemplate(help)
 	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
@@ -158,8 +160,13 @@ var rootCmd = &cobra.Command{
 			m = tpdiscmetrics.NewVictoriaMetrics()
 		}
 
+		var dmsgAddr string
+		if !pk.Null() {
+			dmsgAddr = fmt.Sprintf("%s:%d", pk.Hex(), dmsgPort)
+		}
+
 		enableMetrics := metricsAddr != ""
-		tpdAPI := api.New(logger, s, nonceStore, enableMetrics, m)
+		tpdAPI := api.New(logger, s, nonceStore, enableMetrics, m, dmsgAddr)
 
 		logger.Infof("Listening on %s", addr)
 

--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -63,12 +63,15 @@ type API struct {
 
 	closeOnce sync.Once
 	closeC    chan struct{}
+
+	dmsgAddr string
 }
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
 	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
 	StartedAt time.Time       `json:"started_at"`
+	DmsgAddr  string          `json:"dmsg_address"`
 }
 
 // ArData has all the visors that have registered with sudph or stcpr transport
@@ -84,7 +87,7 @@ type Error struct {
 
 // New creates a new api.
 func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
-	enableMetrics bool, m armetrics.Metrics) *API {
+	enableMetrics bool, m armetrics.Metrics, dmsgAddr string) *API {
 	api := &API{
 		log:                         log,
 		store:                       s,
@@ -93,6 +96,7 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 		udpConns:                    make(map[cipher.PubKey]net.Conn),
 		startedAt:                   time.Now(),
 		closeC:                      make(chan struct{}),
+		dmsgAddr:                    dmsgAddr,
 	}
 
 	r := chi.NewRouter()
@@ -336,6 +340,7 @@ func (a *API) health(w http.ResponseWriter, r *http.Request) {
 	a.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
 		BuildInfo: info,
 		StartedAt: a.startedAt,
+		DmsgAddr:  a.dmsgAddr,
 	})
 }
 

--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -71,7 +71,7 @@ type API struct {
 type HealthCheckResponse struct {
 	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
 	StartedAt time.Time       `json:"started_at"`
-	DmsgAddr  string          `json:"dmsg_address"`
+	DmsgAddr  string          `json:"dmsg_address,omitempty"`
 }
 
 // ArData has all the visors that have registered with sudph or stcpr transport

--- a/pkg/route-finder/api/api.go
+++ b/pkg/route-finder/api/api.go
@@ -29,20 +29,23 @@ type API struct {
 	reqsInFlightCountMiddleware *metricsutil.RequestsInFlightCountMiddleware
 	store                       store.Store
 	startedAt                   time.Time
+	dmsgAddr                    string
 }
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
 	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
 	StartedAt time.Time       `json:"started_at"`
+	DmsgAddr  string          `json:"dmsg_address,omitempty"`
 }
 
 // New creates a new api
-func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool) *API {
+func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr string) *API {
 	api := &API{
 		reqsInFlightCountMiddleware: metricsutil.NewRequestsInFlightCountMiddleware(),
 		store:                       s,
 		startedAt:                   time.Now(),
+		dmsgAddr:                    dmsgAddr,
 	}
 
 	r := chi.NewRouter()
@@ -155,6 +158,7 @@ func (a *API) health(w http.ResponseWriter, r *http.Request) {
 	a.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
 		BuildInfo: info,
 		StartedAt: a.startedAt,
+		DmsgAddr:  a.dmsgAddr,
 	})
 }
 

--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -51,17 +51,19 @@ type API struct {
 	reqsInFlightCountMiddleware *metricsutil.RequestsInFlightCountMiddleware
 	store                       store.Store
 	startedAt                   time.Time
+	dmsgAddr                    string
 }
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
 	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
 	StartedAt time.Time       `json:"started_at"`
+	DmsgAddr  string          `json:"dmsg_address,omitempty"`
 }
 
 // New constructs a new API instance.
 func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
-	enableMetrics bool, m tpdiscmetrics.Metrics) *API {
+	enableMetrics bool, m tpdiscmetrics.Metrics, dmsgAddr string) *API {
 	if log == nil {
 		log = logging.MustGetLogger("tp_disc")
 	}
@@ -71,6 +73,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 		reqsInFlightCountMiddleware: metricsutil.NewRequestsInFlightCountMiddleware(),
 		store:                       s,
 		startedAt:                   time.Now(),
+		dmsgAddr:                    dmsgAddr,
 	}
 
 	r := chi.NewRouter()

--- a/pkg/transport-discovery/api/api_test.go
+++ b/pkg/transport-discovery/api/api_test.go
@@ -72,7 +72,7 @@ func TestBadRequest(t *testing.T) {
 	r := httptest.NewRequest("POST", "/transports/", bytes.NewBufferString("not-a-json"))
 	r.Header = validHeaders(t, []byte("not-a-json"))
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 	api.ServeHTTP(w, r)
 
 	resp := w.Result()
@@ -95,7 +95,7 @@ func TestRegisterTransport(t *testing.T) {
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 	w := httptest.NewRecorder()
 
 	body := bytes.NewBuffer(nil)
@@ -131,7 +131,7 @@ func TestRegisterTimeout(t *testing.T) {
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 
 	// after this ctx's deadline will be exceeded
 	time.Sleep(timeout * 2)
@@ -162,7 +162,7 @@ func TestGETTransportByID(t *testing.T) {
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 
 	entry := newTestEntry()
 	sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
@@ -198,7 +198,7 @@ func TestDELETETransportByID(t *testing.T) {
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 
 	entry := newTestEntry()
 	sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
@@ -220,7 +220,7 @@ func TestDELETETransportByID(t *testing.T) {
 		nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 		require.NoError(t, err)
 
-		api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+		api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 		pk1, _ := cipher.GenerateKeyPair()
 		pk2, _ := cipher.GenerateKeyPair()
 		otherVisorEntry := &transport.Entry{
@@ -256,7 +256,7 @@ func TestGETTransportByEdge(t *testing.T) {
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 
 	entry := newTestEntry()
 	sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
@@ -293,7 +293,7 @@ func TestGETAllTransports(t *testing.T) {
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
 
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 
 	entry1 := newTestEntry()
 	sEntry1 := &transport.SignedEntry{Entry: entry1, Signatures: [2]cipher.Sig{}}
@@ -342,7 +342,7 @@ func TestGETIncrementingNonces(t *testing.T) {
 	ctx := context.TODO()
 	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
 	require.NoError(t, err)
-	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty())
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "")
 
 	t.Run("ValidRequest", func(t *testing.T) {
 		const iterations = 0xFF

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -207,6 +207,7 @@ func (api *API) health(w http.ResponseWriter, r *http.Request) {
 	api.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
 		BuildInfo: info,
 		StartedAt: api.startedAt,
+		DmsgAddr:  api.dmsgAddr,
 	})
 }
 


### PR DESCRIPTION
Fixes: #12 

Changes:
- add `dmsg_address` field to `/health` endpoint of services

How to test?:
- clone `skywire-ut` repo from this PR and its branch https://github.com/skycoin/skywire-ut/pull/6
- clone `skycoin-service-discovery` repo from this PR and its branch https://github.com/skycoin/skycoin-service-discovery/pull/8
- clone `dmsg` from this PR https://github.com/skycoin/dmsg/pull/224
- clone current `skywire-services` PR, add `--sk 10f6cfb0e4eff6c7472649bcd98dd343fd72e10f5144bf7572221765898d063e` to `docker-compose.yml` file in entrypoint value of services config's same as bellow:

  ```
  address-resolver:
    privileged: true
    image: "${REGISTRY}/address-resolver:${DOCKER_TAG}"
    hostname: address-resolver
    container_name: "address-resolver"
    networks:
      srv:
        ipv4_address: 175.0.0.8
      intra:
        ipv4_address: 174.0.0.8
    ports:
      - "9093:9093"
    depends_on:
      - ar-redis
    restart: on-failure
    entrypoint: "/release/address-resolver --redis redis://ar-redis:6379 --sk 10f6cfb0e4eff6c7472649bcd98dd343fd72e10f5144bf7572221765898d063e"
    stdin_open: true # docker run -i
    tty: true        # docker run -t
  ```
  Note: you should add this flag for `uptime-tracker`, `service-discovery`, `dmsg-discovery`, `route-finder`, `address-resolver` and `transport-discovery`
- build and run integration-env by `make integration-env-build` 
- check related endpoints for `dmsg_address` values:
  |      **Service**      |            **URL**           |
  |:---------------------:|:----------------------------:|
  |    `dmsg_discovery`   | http://175.0.0.4:9090/health |
  | `transport_discovery` | http://175.0.0.2:9091/health |
  |     `route_finder`    | http://175.0.0.3:9092/health |
  |   `address_resolver`  | http://175.0.0.8:9093/health |
  |    `uptime_tracker`   | http://175.0.0.7:9096/health |
  |  `service_discovery`  | http://175.0.0.9:9098/health |

  Note: you can check these URLs by browser or by `curl` command:
  
    <img width="1392" alt="image" src="https://github.com/skycoin/skywire-services/assets/79150699/e76093c8-bc4d-48fc-8351-8d0e476660bd">

We should get `03b09f987a5042ff445c34bdb1d86ea78ffa84bc4ea87c87b65cd052f376ac5894:80` as `dmsg_address` value on all services health endpoint.