### PR TITLE
dmsghttp config endpoint

### DIFF
--- a/pkg/config-bootstrapper/api/api.go
+++ b/pkg/config-bootstrapper/api/api.go
@@ -3,6 +3,8 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -28,6 +30,9 @@ type API struct {
 	startedAt time.Time
 
 	services *visorconfig.Services
+
+	dmsghttpConf   httputil.DMSGHTTPConf
+	dmsghttpConfTs time.Time
 
 	closeOnce sync.Once
 	closeC    chan struct{}
@@ -75,10 +80,11 @@ func New(log *logging.Logger, conf Config, domain string) *API {
 	}
 
 	api := &API{
-		log:       log,
-		startedAt: time.Now(),
-		services:  services,
-		closeC:    make(chan struct{}),
+		log:            log,
+		startedAt:      time.Now(),
+		services:       services,
+		dmsghttpConfTs: time.Now().Add(-5 * time.Minute),
+		closeC:         make(chan struct{}),
 	}
 
 	r := chi.NewRouter()
@@ -90,6 +96,7 @@ func New(log *logging.Logger, conf Config, domain string) *API {
 	r.Use(httputil.SetLoggerMiddleware(log))
 	r.Get("/health", api.health)
 	r.Get("/", api.config)
+	r.Get("/dmsghttp", api.dmsghttp)
 
 	api.Handler = r
 
@@ -116,7 +123,6 @@ func (a *API) health(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) config(w http.ResponseWriter, r *http.Request) {
-
 	a.writeJSON(w, r, http.StatusOK, a.services)
 }
 
@@ -136,4 +142,59 @@ func (a *API) writeJSON(w http.ResponseWriter, r *http.Request, code int, object
 	if err != nil {
 		a.logger(r).WithError(err).Errorf("failed to write json response")
 	}
+}
+
+func (a *API) dmsghttp(w http.ResponseWriter, r *http.Request) {
+	if time.Now().Add(-5 * time.Minute).After(a.dmsghttpConfTs) {
+		a.dmsghttpConf = a.dmsghttpConfGen()
+		a.dmsghttpConfTs = time.Now()
+	}
+	a.writeJSON(w, r, http.StatusOK, a.dmsghttpConf)
+}
+
+func (a *API) dmsghttpConfGen() httputil.DMSGHTTPConf {
+	var dmsghttpConf httputil.DMSGHTTPConf
+	dmsghttpConf.DMSGServers = fetchDMSGServers(a.services.DmsgDiscovery)
+	dmsghttpConf.AddressResolver = fetchDMSGAddress(a.services.AddressResolver)
+	dmsghttpConf.DMSGDiscovery = fetchDMSGAddress(a.services.DmsgDiscovery)
+	dmsghttpConf.RouteFinder = fetchDMSGAddress(a.services.RouteFinder)
+	dmsghttpConf.ServiceDiscovery = fetchDMSGAddress(a.services.ServiceDiscovery)
+	dmsghttpConf.TranspordDiscovery = fetchDMSGAddress(a.services.TransportDiscovery)
+	dmsghttpConf.UptimeTracker = fetchDMSGAddress(a.services.UptimeTracker)
+
+	return dmsghttpConf
+}
+
+func fetchDMSGAddress(url string) string {
+	resp, err := http.Get(fmt.Sprintf("%s/health", url))
+	if err != nil {
+		return ""
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ""
+	}
+	var healthResponse httputil.HealthCheckResponse
+	err = json.Unmarshal(body, &healthResponse)
+	if err != nil {
+		return ""
+	}
+	return healthResponse.DmsgAddr
+}
+
+func fetchDMSGServers(url string) []httputil.DMSGServersConf {
+	var dmsgServersList []httputil.DMSGServersConf
+	resp, err := http.Get(fmt.Sprintf("%s/dmsg-discovery/all_servers", url))
+	if err != nil {
+		return dmsgServersList
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return dmsgServersList
+	}
+	err = json.Unmarshal(body, &dmsgServersList)
+	if err != nil {
+		return dmsgServersList
+	}
+	return dmsgServersList
 }


### PR DESCRIPTION
Fixes: https://github.com/skycoin/skywire/issues/1603

Changes:
- add new endpoint `/dmsghttp` to config bootstrap api service

How to test?:
- run config bootstrap with `-d skywire.dev` for checking dmsg-address of UT service (other services on test env not restarted with new image)
  
![image](https://github.com/skycoin/skywire-services/assets/79150699/e8f6636e-f3ed-4ad7-ad58-212d0ffa47ce)

- run config boostrap without any flag (as prod env) for checking dmsg-servers list.
  
![image](https://github.com/skycoin/skywire-services/assets/79150699/4232d863-008b-43e2-939c-6888118590a0)

