### PR TITLE
Remove logEnabled flag and add loglvl flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ e2e-help: ## E2E. Show env-vars and useful commands
 
 docker-push-test:
 	bash ./docker/docker_build.sh test ${BUILD_OPTS_DEPLOY}
-	bash ./docker/docker_push.sh test
+	# bash ./docker/docker_push.sh test
 
 docker-push:
 	bash ./docker/docker_build.sh prod ${BUILD_OPTS_DEPLOY}

--- a/cmd/config-bootstrapper/commands/root.go
+++ b/cmd/config-bootstrapper/commands/root.go
@@ -112,13 +112,12 @@ func readConfig(log *logging.Logger, confPath string) (config api.Config) {
 func Execute() {
 	cc.Init(&cc.Config{
 		RootCmd:       rootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
+		Headings:      cc.HiBlue + cc.Bold,
 		Commands:      cc.HiBlue + cc.Bold,
 		CmdShortDescr: cc.HiBlue,
 		Example:       cc.HiBlue + cc.Italic,
 		ExecName:      cc.HiBlue + cc.Bold,
 		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
 		FlagsDescr:      cc.HiBlue,
 		NoExtraNewlines: true,
 		NoBottomNewline: true,

--- a/cmd/liveness-checker/commands/root.go
+++ b/cmd/liveness-checker/commands/root.go
@@ -30,6 +30,7 @@ var (
 	addr       string
 	tag        string
 	syslogAddr string
+	logLvl     string
 	redisURL   string
 	testing    bool
 )
@@ -39,6 +40,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&confPath, "config", "c", "liveness-checker.json", "config file location.\033[0m")
 	rootCmd.Flags().StringVar(&tag, "tag", "liveness_checker", "logging tag\033[0m")
 	rootCmd.Flags().StringVar(&syslogAddr, "syslog", "", "syslog server address. E.g. localhost:514\033[0m")
+	rootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "set log level one of: info, error, warn, debug, trace, panic")
 	rootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\033[0m")
 	rootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis\033[0m")
 	var helpflag bool
@@ -80,6 +82,13 @@ var rootCmd = &cobra.Command{
 		}
 
 		mLogger := logging.NewMasterLogger()
+		lvl, err := logging.LevelFromString(logLvl)
+		if err != nil {
+			mLogger.Fatal("Invalid loglvl detected")
+		}
+
+		logging.SetLevel(lvl)
+
 		conf, confAPI := api.InitConfig(confPath, mLogger)
 
 		logger := mLogger.PackageLogger(tag)

--- a/cmd/network-monitor/commands/root.go
+++ b/cmd/network-monitor/commands/root.go
@@ -38,6 +38,7 @@ var (
 	addr                string
 	tag                 string
 	syslogAddr          string
+	logLvl              string
 	metricsAddr         string
 	redisURL            string
 	testing             bool
@@ -55,6 +56,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&utURL, "ut-url", "u", "", "url to uptime tracker visor data.\033[0m")
 	rootCmd.Flags().StringVar(&tag, "tag", "network_monitor", "logging tag\033[0m")
 	rootCmd.Flags().StringVar(&syslogAddr, "syslog", "", "syslog server address. E.g. localhost:514\033[0m")
+	rootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "set log level one of: info, error, warn, debug, trace, panic")
 	rootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to\033[0m")
 	rootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\033[0m")
 	rootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis\033[0m")
@@ -104,6 +106,12 @@ var rootCmd = &cobra.Command{
 		}
 
 		mLogger := logging.NewMasterLogger()
+		lvl, err := logging.LevelFromString(logLvl)
+		if err != nil {
+			mLogger.Fatal("Invalid loglvl detected")
+		}
+
+		logging.SetLevel(lvl)
 		conf := api.InitConfig(confPath, mLogger)
 
 		if sdURL == "" {

--- a/cmd/public-visor-monitor/commands/root.go
+++ b/cmd/public-visor-monitor/commands/root.go
@@ -26,6 +26,7 @@ var (
 	confPath            string
 	addr                string
 	tag                 string
+	logLvl              string
 	sleepDeregistration time.Duration
 )
 
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.Flags().DurationVarP(&sleepDeregistration, "sleep-deregistration", "s", 10, "Sleep time for derigstration process in minutes\033[0m")
 	rootCmd.Flags().StringVarP(&confPath, "config", "c", "public-visor-monitor.json", "config file location.\033[0m")
 	rootCmd.Flags().StringVar(&tag, "tag", "public_visor_monitor", "logging tag\033[0m")
+	rootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "set log level one of: info, error, warn, debug, trace, panic")
 	var helpflag bool
 	rootCmd.SetUsageTemplate(help)
 	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
@@ -60,6 +62,13 @@ var rootCmd = &cobra.Command{
 		}
 
 		mLogger := logging.NewMasterLogger()
+		lvl, err := logging.LevelFromString(logLvl)
+		if err != nil {
+			mLogger.Fatal("Invalid loglvl detected")
+		}
+
+		logging.SetLevel(lvl)
+
 		conf := initConfig(confPath, visorBuildInfo, mLogger)
 
 		srvURLs := api.ServicesURLs{

--- a/cmd/route-finder/commands/root.go
+++ b/cmd/route-finder/commands/root.go
@@ -33,8 +33,8 @@ var (
 	metricsAddr string
 	pgHost      string
 	pgPort      string
-	logEnabled  bool
 	syslogAddr  string
+	logLvl      string
 	tag         string
 	testing     bool
 	dmsgDisc    string
@@ -45,10 +45,10 @@ var (
 func init() {
 	rootCmd.Flags().StringVarP(&addr, "addr", "a", ":9092", "address to bind to\033[0m")
 	rootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to\033[0m")
-	rootCmd.Flags().BoolVarP(&logEnabled, "log", "l", true, "enable request logging\033[0m")
 	rootCmd.Flags().StringVar(&pgHost, "pg-host", "localhost", "host of postgres\033[0m")
 	rootCmd.Flags().StringVar(&pgPort, "pg-port", "5432", "port of postgres\033[0m")
 	rootCmd.Flags().StringVar(&syslogAddr, "syslog", "", "syslog server address. E.g. localhost:514\033[0m")
+	rootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "set log level one of: info, error, warn, debug, trace, panic")
 	rootCmd.Flags().StringVar(&tag, "tag", "route_finder", "logging tag\033[0m")
 	rootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis\033[0m")
 	rootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", "http://dmsgd.skywire.skycoin.com", "url of dmsg-discovery\033[0m")
@@ -80,15 +80,15 @@ var rootCmd = &cobra.Command{
 
 		memoryStore := true
 
-		var logger *logging.Logger
-		if logEnabled {
-			logger = logging.MustGetLogger(tag)
-		} else {
-			logger = nil
+		logger := logging.MustGetLogger(tag)
+		lvl, err := logging.LevelFromString(logLvl)
+		if err != nil {
+			logger.Fatal("Invalid loglvl detected")
 		}
 
+		logging.SetLevel(lvl)
+
 		var gormDB *gorm.DB
-		var err error
 
 		if !testing {
 			pgUser, pgPassword, pgDatabase := storeconfig.PostgresCredential()

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -43,8 +43,8 @@ var (
 	redisPoolSize int
 	pgHost        string
 	pgPort        string
-	logEnabled    bool
 	syslogAddr    string
+	logLvl        string
 	tag           string
 	testing       bool
 	dmsgDisc      string
@@ -59,8 +59,8 @@ func init() {
 	rootCmd.Flags().IntVar(&redisPoolSize, "redis-pool-size", 10, "redis connection pool size\033[0m")
 	rootCmd.Flags().StringVar(&pgHost, "pg-host", "localhost", "host of postgres\033[0m")
 	rootCmd.Flags().StringVar(&pgPort, "pg-port", "5432", "port of postgres\033[0m")
-	rootCmd.Flags().BoolVarP(&logEnabled, "log", "l", true, "enable request logging\033[0m")
 	rootCmd.Flags().StringVar(&syslogAddr, "syslog", "", "syslog server address. E.g. localhost:514\033[0m")
+	rootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "set log level one of: info, error, warn, debug, trace, panic")
 	rootCmd.Flags().StringVar(&tag, "tag", "transport_discovery", "logging tag\033[0m")
 	rootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis\033[0m")
 	rootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", "http://dmsgd.skywire.skycoin.com", "url of dmsg-discovery\033[0m")
@@ -101,8 +101,14 @@ var rootCmd = &cobra.Command{
 			PoolSize: redisPoolSize,
 		}
 
-		const loggerTag = "transport_discovery"
-		logger := logging.MustGetLogger(loggerTag)
+		logger := logging.MustGetLogger(tag)
+		lvl, err := logging.LevelFromString(logLvl)
+		if err != nil {
+			logger.Fatal("Invalid loglvl detected")
+		}
+
+		logging.SetLevel(lvl)
+
 		if syslogAddr != "" {
 			hook, err := logrussyslog.NewSyslogHook("udp", syslogAddr, syslog.LOG_INFO, tag)
 			if err != nil {
@@ -112,7 +118,6 @@ var rootCmd = &cobra.Command{
 		}
 
 		var gormDB *gorm.DB
-		var err error
 
 		if !testing {
 			pgUser, pgPassword, pgDatabase := storeconfig.PostgresCredential()

--- a/cmd/transport-setup/commands/root.go
+++ b/cmd/transport-setup/commands/root.go
@@ -16,10 +16,14 @@ import (
 	"github.com/skycoin/skywire-services/pkg/transport-setup/config"
 )
 
-var configFile string
+var (
+	logLvl     string
+	configFile string
+)
 
 func init() {
 	rootCmd.Flags().StringVarP(&configFile, "config", "c", "", "path to config file\033[0m")
+	rootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "set log level one of: info, error, warn, debug, trace, panic")
 	err := rootCmd.MarkFlagRequired("config")
 	if err != nil {
 		log.Fatal("config flag is not specified")
@@ -44,7 +48,6 @@ var rootCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Version:               buildinfo.Version(),
 	Run: func(_ *cobra.Command, args []string) {
-		// local config of the client
 		const loggerTag = "transport_setup"
 		log := logging.MustGetLogger(loggerTag)
 		conf := config.MustReadConfig(configFile, log)

--- a/cmd/transport-setup/commands/root.go
+++ b/cmd/transport-setup/commands/root.go
@@ -50,6 +50,12 @@ var rootCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, args []string) {
 		const loggerTag = "transport_setup"
 		log := logging.MustGetLogger(loggerTag)
+		lvl, err := logging.LevelFromString(logLvl)
+		if err != nil {
+			log.Fatal("Invalid loglvl detected")
+		}
+		logging.SetLevel(lvl)
+
 		conf := config.MustReadConfig(configFile, log)
 		api := api.New(log, conf)
 		srv := &http.Server{

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -9,6 +9,7 @@ nv_dev_url="https://nv.skywire.dev/map"
 nv_prod_url="https://nv.skycoin.com/map"
 nv_e2e_url="https://localhost:9081/map"
 bldkit="1"
+platform="--platform=linux/amd64"
 
 # shellcheck disable=SC2153
 registry="$REGISTRY"
@@ -91,6 +92,7 @@ if [[ "$image_tag" == "e2e" ]]; then
     --build-arg base_image="$base_image" \
     --build-arg build_opts="$go_buildopts" \
     --build-arg image_tag="$image_tag" \
+    $platform \
     -t "$registry"/service-discovery:"$image_tag" .
   
   echo "building uptime tracker image"
@@ -173,6 +175,7 @@ DOCKER_BUILDKIT="$bldkit" docker build -f docker/images/address-resolver/Dockerf
   --build-arg build_opts="$go_buildopts" \
   --build-arg image_tag="$image_tag" \
   --build-arg base_image="$base_image" \
+  $platform \
   -t "$registry"/address-resolver:"$image_tag" .
 
 if [[ "$image_tag" == "test" ]]; then

--- a/pkg/node-visualizer/web/.env
+++ b/pkg/node-visualizer/web/.env
@@ -1,1 +1,1 @@
-REACT_APP_SKY_NODEVIZ_URL=https://nv.skycoin.com/map
+REACT_APP_SKY_NODEVIZ_URL=https://nv.skywire.dev/map


### PR DESCRIPTION
Added loglevel flag (shorthand -l) to most of the services where we use different loglevels and where logging could be useful.

Removed logEnabled from AR, RF and TPD because it appears useless.

How to test:

1. Build service like AR with

`go build cmd/address-resolver/address-resolver.go`

2. Start redis-server with 

`redis-server`

3. Check logs after setting different log levels. 

Fixes #15 