### PR TITLE
Fix `make check` errors with latest golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ format: dep ## Formats the code. Must have goimports and goimports-reviser insta
 	goimports -w -local github.com/skycoin/skywire-services ./pkg
 	goimports -w -local github.com/skycoin/skywire-services ./cmd
 	goimports -w -local github.com/skycoin/skywire-services ./internal
-	find . -type f -name '*.go' -not -path "./vendor/*" -exec goimports-reviser -project-name ${PROJECT_BASE} -file-path {} \;
+	find . -type f -name '*.go' -not -path "./vendor/*" -exec goimports-reviser -project-name ${PROJECT_BASE} {} \;
 
 ## : ## _ [Build, install, clean]
 

--- a/cmd/keys-gen/commands/root.go
+++ b/cmd/keys-gen/commands/root.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"log"
 
+	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
-
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/vpn-lite-client/vpn-lite-client.go
+++ b/cmd/vpn-lite-client/vpn-lite-client.go
@@ -10,13 +10,14 @@ import (
 	"syscall"
 
 	cc "github.com/ivanpirog/coloredcobra"
-	"github.com/skycoin/skywire-services/internal/vpn"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire-services/internal/vpn"
 )
 
 var (

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -343,7 +343,7 @@ func (c *Client) isClosed() bool {
 }
 
 // SetupTUN sets the allocated TUN interface up, setting its IP, gateway, netmask and MTU.
-func SetupTUN(ifcName, ipCIDR, gateway string, mtu int) error {
+func SetupTUN(ifcName, ipCIDR, _ string, mtu int) error {
 	if err := osutil.Run("ip", "a", "add", ipCIDR, "dev", ifcName); err != nil {
 		return fmt.Errorf("error assigning IP: %w", err)
 	}

--- a/pkg/network-monitor/api/api.go
+++ b/pkg/network-monitor/api/api.go
@@ -358,16 +358,17 @@ func (api *API) testTransport(key cipher.PubKey, transport network.Type, ch chan
 			api.logger.WithField("Retry", 4-retrier).WithError(err).Warnf("Failed to establish %v transport to %v", transport, key)
 			retrier--
 			continue
-		} else {
-			api.logger.Infof("Established %v transport to %v", transport, key)
-			isUp = true
-			err = api.Visor.RemoveTransport(tp.ID)
-			if err != nil {
-				api.logger.Warnf("Error removing %v transport of %v: %v", transport, key, err)
-			}
-			retrier = 0
 		}
+
+		api.logger.Infof("Established %v transport to %v", transport, key)
+		isUp = true
+		err = api.Visor.RemoveTransport(tp.ID)
+		if err != nil {
+			api.logger.Warnf("Error removing %v transport of %v: %v", transport, key, err)
+		}
+		retrier = 0
 	}
+
 	ch <- isUp
 }
 

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -35,7 +35,7 @@ func (m *mockStore) DeregisterTransport(context.Context, uuid.UUID) error {
 func (m *mockStore) GetTransportByID(context.Context, uuid.UUID) (*transport.Entry, error) {
 	return nil, nil
 }
-func (m *mockStore) GetTransportsByEdge(ctx context.Context, edgePK cipher.PubKey) ([]*transport.Entry, error) {
+func (m *mockStore) GetTransportsByEdge(_ context.Context, edgePK cipher.PubKey) ([]*transport.Entry, error) {
 	trs, ok := m.transports[edgePK]
 	if !ok {
 		return nil, ErrNoNodeInMockStore
@@ -52,7 +52,7 @@ func (m *mockStore) GetAllTransports(context.Context) ([]*transport.Entry, error
 func (m *mockStore) Close() {}
 
 // SaveEntry is added to the mock to allow saving Entry, without need for SignedEntry
-func (m *mockStore) SaveEntry(source, destiny cipher.PubKey, isUp bool) {
+func (m *mockStore) SaveEntry(source, destiny cipher.PubKey, _ bool) {
 	entry := &transport.Entry{
 		Edges: transport.SortEdges(source, destiny), // original: [2]cipher.PubKey{source, destiny}
 	}

--- a/pkg/transport-discovery/store/postgres_store.go
+++ b/pkg/transport-discovery/store/postgres_store.go
@@ -45,18 +45,11 @@ func (s *postgresStore) RegisterTransport(_ context.Context, sEntry *transport.S
 	tpRecord.Type = string(entry.Type)
 	tpRecord.Label = string(entry.Label)
 
-	if err := s.client.Save(&tpRecord).Error; err != nil {
-		return err
-	}
-
-	return nil
+	return s.client.Save(&tpRecord).Error
 }
 
-func (s *postgresStore) DeregisterTransport(ctx context.Context, id uuid.UUID) error {
-	if err := s.client.Where("transport_id = ?", id).Delete(&Transport{}).Error; err != nil {
-		return err
-	}
-	return nil
+func (s *postgresStore) DeregisterTransport(ctx context.Context, id uuid.UUID) error { //nolint
+	return s.client.Where("transport_id = ?", id).Delete(&Transport{}).Error
 }
 
 func (s *postgresStore) GetTransportByID(_ context.Context, id uuid.UUID) (*transport.Entry, error) {


### PR DESCRIPTION
the following errors on `make format check` were addressed:

```
All changes to file are applied, but command-line syntax should be fixed
-file-path is deprecated. Put file name as last argument to the command(Example: goimports-reviser -rm-unused -set-alias -format goimports-reviser/main.go)
All changes to file are applied, but command-line syntax should be fixed
golangci-lint run -c .golangci.yml ./...
pkg/network-monitor/api/api.go:361:10: superfluous-else: if block ends with a continue statement, so drop this else and outdent its block (revive)
		} else {
			api.logger.Infof("Established %v transport to %v", transport, key)
			isUp = true
			err = api.Visor.RemoveTransport(tp.ID)
			if err != nil {
				api.logger.Warnf("Error removing %v transport of %v: %v", transport, key, err)
			}
			retrier = 0
		}
pkg/transport-discovery/store/postgres_store.go:48:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
	if err := s.client.Save(&tpRecord).Error; err != nil {
		return err
	}
pkg/transport-discovery/store/postgres_store.go:56:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
	if err := s.client.Where("transport_id = ?", id).Delete(&Transport{}).Error; err != nil {
		return err
	}
pkg/transport-discovery/store/postgres_store.go:55:45: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (s *postgresStore) DeregisterTransport(ctx context.Context, id uuid.UUID) error {
                                            ^
pkg/route-finder/store/graph_test.go:38:41: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (m *mockStore) GetTransportsByEdge(ctx context.Context, edgePK cipher.PubKey) ([]*transport.Entry, error) {
                                        ^
pkg/route-finder/store/graph_test.go:55:62: unused-parameter: parameter 'isUp' seems to be unused, consider removing or renaming it as _ (revive)
func (m *mockStore) SaveEntry(source, destiny cipher.PubKey, isUp bool) {
                                                             ^
internal/vpn/client.go:346:32: unused-parameter: parameter 'gateway' seems to be unused, consider removing or renaming it as _ (revive)
func SetupTUN(ifcName, ipCIDR, gateway string, mtu int) error {
                               ^
make: *** [Makefile:138: lint] Error 1

```

![image](https://github.com/skycoin/skywire-services/assets/36607567/63fd6e9a-83c3-4915-8024-694cabe69d52)
