### PR TITLE
improve `/health` endpoint informations

### DIFF
--- a/cmd/address-resolver/commands/root.go
+++ b/cmd/address-resolver/commands/root.go
@@ -8,6 +8,7 @@ import (
 	"log/syslog"
 	"os"
 	"strings"
+	"time"
 
 	cc "github.com/ivanpirog/coloredcobra"
 	logrussyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -206,6 +207,13 @@ var RootCmd = &cobra.Command{
 			}
 
 			defer closeDmsgDC()
+
+			go func() {
+				for {
+					arAPI.DmsgServers = dmsgDC.ConnectedServersPK()
+					time.Sleep(time.Second)
+				}
+			}()
 
 			go dmsghttp.UpdateServers(ctx, dClient, dmsgDisc, dmsgDC, logger)
 

--- a/cmd/route-finder/commands/root.go
+++ b/cmd/route-finder/commands/root.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"log/syslog"
 	"os"
+	"time"
 
 	cc "github.com/ivanpirog/coloredcobra"
 	logrussyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -167,6 +168,13 @@ var RootCmd = &cobra.Command{
 			}
 
 			defer closeDmsgDC()
+
+			go func() {
+				for {
+					rfAPI.DmsgServers = dmsgDC.ConnectedServersPK()
+					time.Sleep(time.Second)
+				}
+			}()
 
 			go dmsghttp.UpdateServers(ctx, dClient, dmsgDisc, dmsgDC, logger)
 

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -8,6 +8,7 @@ import (
 	"log/syslog"
 	"os"
 	"strings"
+	"time"
 
 	cc "github.com/ivanpirog/coloredcobra"
 	logrussyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -202,6 +203,13 @@ var RootCmd = &cobra.Command{
 			}
 
 			defer closeDmsgDC()
+
+			go func() {
+				for {
+					tpdAPI.DmsgServers = dmsgDC.ConnectedServersPK()
+					time.Sleep(time.Second)
+				}
+			}()
 
 			go dmsghttp.UpdateServers(ctx, dClient, dmsgDisc, dmsgDC, logger)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -167,7 +167,7 @@ services:
     depends_on:
       - tpd-redis
       - postgres-db
-    entrypoint: "/release/transport-discovery --pg-host postgres-db --pg-port 5432 --redis redis://tpd-redis:6379"
+    entrypoint: "/release/transport-discovery --pg-host postgres-db --pg-port 5432 --redis redis://tpd-redis:6379 --sk 85789cd7efcdf35340c8f4cb3e15bccdff57efda49af5bcdddaae57374d25ab8"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -190,7 +190,7 @@ services:
       - "9092:9092"
     depends_on:
       - transport-discovery
-    entrypoint: "/release/route-finder --pg-host postgres-db --pg-port 5432"
+    entrypoint: "/release/route-finder --pg-host postgres-db --pg-port 5432 --sk 640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -209,7 +209,7 @@ services:
     depends_on:
       - dmsgd-redis
       - transport-discovery
-    entrypoint: "/usr/local/bin/dmsg-discovery --redis redis://dmsgd-redis:6379 -t"
+    entrypoint: "/usr/local/bin/dmsg-discovery --redis redis://dmsgd-redis:6379 --sk b3f6706cb72215d3873ef92cc0c6037a47fe651112b1685017d6347eed0fb714 -t"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -279,7 +279,7 @@ services:
       - PG_USER=postgres
       - PG_PASSWORD=postgres
       - PG_DATABASE=postgres
-    entrypoint: "/release/service-discovery --pg-host postgres-db --pg-port 5432 --redis redis://sd-redis:6379"
+    entrypoint: "/release/service-discovery --pg-host postgres-db --pg-port 5432 --redis redis://sd-redis:6379 --sk ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -303,7 +303,7 @@ services:
       - PG_DATABASE=postgres
     ports:
       - "9096:9096"
-    entrypoint: "/release/uptime-tracker --pg-host postgres-db --pg-port 5432 --redis redis://ut-redis:6379"
+    entrypoint: "/release/uptime-tracker --pg-host postgres-db --pg-port 5432 --redis redis://ut-redis:6379 --sk e20681b4fd1eb1904ebfbf8fba79a138bbac481e1c3f77bcfab3a877525fda32"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -322,7 +322,7 @@ services:
     depends_on:
       - ar-redis
     restart: on-failure
-    entrypoint: "/release/address-resolver --redis redis://ar-redis:6379"
+    entrypoint: "/release/address-resolver --redis redis://ar-redis:6379 --sk 1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -167,7 +167,7 @@ services:
     depends_on:
       - tpd-redis
       - postgres-db
-    entrypoint: "/release/transport-discovery --pg-host postgres-db --pg-port 5432 --redis redis://tpd-redis:6379 --sk 85789cd7efcdf35340c8f4cb3e15bccdff57efda49af5bcdddaae57374d25ab8"
+    entrypoint: "/release/transport-discovery --pg-host postgres-db --pg-port 5432 --redis redis://tpd-redis:6379 --sk 85789cd7efcdf35340c8f4cb3e15bccdff57efda49af5bcdddaae57374d25ab8 --dmsg-disc http://dmsg-discovery:9090"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -190,7 +190,7 @@ services:
       - "9092:9092"
     depends_on:
       - transport-discovery
-    entrypoint: "/release/route-finder --pg-host postgres-db --pg-port 5432 --sk 640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca"
+    entrypoint: "/release/route-finder --pg-host postgres-db --pg-port 5432 --sk 640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca --dmsg-disc http://dmsg-discovery:9090"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -279,7 +279,7 @@ services:
       - PG_USER=postgres
       - PG_PASSWORD=postgres
       - PG_DATABASE=postgres
-    entrypoint: "/release/service-discovery --pg-host postgres-db --pg-port 5432 --redis redis://sd-redis:6379 --sk ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f"
+    entrypoint: "/release/service-discovery --pg-host postgres-db --pg-port 5432 --redis redis://sd-redis:6379 --sk ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f --dmsg-disc http://dmsg-discovery:9090"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -303,7 +303,7 @@ services:
       - PG_DATABASE=postgres
     ports:
       - "9096:9096"
-    entrypoint: "/release/uptime-tracker --pg-host postgres-db --pg-port 5432 --redis redis://ut-redis:6379 --sk e20681b4fd1eb1904ebfbf8fba79a138bbac481e1c3f77bcfab3a877525fda32"
+    entrypoint: "/release/uptime-tracker --pg-host postgres-db --pg-port 5432 --redis redis://ut-redis:6379 --sk e20681b4fd1eb1904ebfbf8fba79a138bbac481e1c3f77bcfab3a877525fda32 --dmsg-disc http://dmsg-discovery:9090"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -322,7 +322,7 @@ services:
     depends_on:
       - ar-redis
     restart: on-failure
-    entrypoint: "/release/address-resolver --redis redis://ar-redis:6379 --sk 1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a"
+    entrypoint: "/release/address-resolver --redis redis://ar-redis:6379 --sk 1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a --dmsg-disc http://dmsg-discovery:9090"
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 

--- a/docker/images/dmsg-discovery/DockerfileInt
+++ b/docker/images/dmsg-discovery/DockerfileInt
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.21-alpine AS builder
 ARG CGO_ENABLED=0
 
 ENV CGO_ENABLED=${CGO_ENABLED} \

--- a/docker/images/dmsg-server/DockerfileInt
+++ b/docker/images/dmsg-server/DockerfileInt
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.21-alpine AS builder
 ARG CGO_ENABLED=0
 
 ENV CGO_ENABLED=${CGO_ENABLED} \

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/rs/cors v1.8.2
 	github.com/sirupsen/logrus v1.9.3
-	github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5
+	github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01
 	github.com/skycoin/skywire v1.3.14-0.20231120181804-7c5994927a04
 	github.com/skycoin/skywire-utilities v0.0.0-20231120175000-12be4345eb26
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5 h1:yGTInFb9SqchM5w0RrFA4vgq9tzhKQStURpetUor+4s=
 github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5/go.mod h1:HPGbmjaaKzGGOL8B0Rksc9+asBEAjnmPkJ2t1Hfl+uI=
+github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01 h1:dZD0r4a6pyCpyMYzQxdatmmTScpNj0gYlPQghKfBKes=
+github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01/go.mod h1:HPGbmjaaKzGGOL8B0Rksc9+asBEAjnmPkJ2t1Hfl+uI=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=

--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -64,14 +64,16 @@ type API struct {
 	closeOnce sync.Once
 	closeC    chan struct{}
 
-	dmsgAddr string
+	dmsgAddr    string
+	DmsgServers []string
 }
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
-	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
-	StartedAt time.Time       `json:"started_at"`
-	DmsgAddr  string          `json:"dmsg_address,omitempty"`
+	BuildInfo   *buildinfo.Info `json:"build_info,omitempty"`
+	StartedAt   time.Time       `json:"started_at"`
+	DmsgAddr    string          `json:"dmsg_address,omitempty"`
+	DmsgServers []string        `json:"dmsg_servers,omitempty"`
 }
 
 // ArData has all the visors that have registered with sudph or stcpr transport
@@ -97,6 +99,7 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 		startedAt:                   time.Now(),
 		closeC:                      make(chan struct{}),
 		dmsgAddr:                    dmsgAddr,
+		DmsgServers:                 []string{},
 	}
 
 	r := chi.NewRouter()
@@ -338,9 +341,10 @@ func (a *API) resolve(w http.ResponseWriter, r *http.Request) {
 func (a *API) health(w http.ResponseWriter, r *http.Request) {
 	info := buildinfo.Get()
 	a.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
-		BuildInfo: info,
-		StartedAt: a.startedAt,
-		DmsgAddr:  a.dmsgAddr,
+		BuildInfo:   info,
+		StartedAt:   a.startedAt,
+		DmsgAddr:    a.dmsgAddr,
+		DmsgServers: a.DmsgServers,
 	})
 }
 

--- a/pkg/route-finder/api/api.go
+++ b/pkg/route-finder/api/api.go
@@ -30,13 +30,15 @@ type API struct {
 	store                       store.Store
 	startedAt                   time.Time
 	dmsgAddr                    string
+	DmsgServers                 []string
 }
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
-	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
-	StartedAt time.Time       `json:"started_at"`
-	DmsgAddr  string          `json:"dmsg_address,omitempty"`
+	BuildInfo   *buildinfo.Info `json:"build_info,omitempty"`
+	StartedAt   time.Time       `json:"started_at"`
+	DmsgAddr    string          `json:"dmsg_address,omitempty"`
+	DmsgServers []string        `json:"dmsg_servers,omitempty"`
 }
 
 // New creates a new api
@@ -46,6 +48,7 @@ func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr 
 		store:                       s,
 		startedAt:                   time.Now(),
 		dmsgAddr:                    dmsgAddr,
+		DmsgServers:                 []string{},
 	}
 
 	r := chi.NewRouter()
@@ -156,9 +159,10 @@ func (a *API) getPairedRoutes(w http.ResponseWriter, r *http.Request) {
 func (a *API) health(w http.ResponseWriter, r *http.Request) {
 	info := buildinfo.Get()
 	a.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
-		BuildInfo: info,
-		StartedAt: a.startedAt,
-		DmsgAddr:  a.dmsgAddr,
+		BuildInfo:   info,
+		StartedAt:   a.startedAt,
+		DmsgAddr:    a.dmsgAddr,
+		DmsgServers: a.DmsgServers,
 	})
 }
 

--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -52,13 +52,15 @@ type API struct {
 	store                       store.Store
 	startedAt                   time.Time
 	dmsgAddr                    string
+	DmsgServers                 []string
 }
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
-	BuildInfo *buildinfo.Info `json:"build_info,omitempty"`
-	StartedAt time.Time       `json:"started_at"`
-	DmsgAddr  string          `json:"dmsg_address,omitempty"`
+	BuildInfo   *buildinfo.Info `json:"build_info,omitempty"`
+	StartedAt   time.Time       `json:"started_at"`
+	DmsgAddr    string          `json:"dmsg_address,omitempty"`
+	DmsgServers []string        `json:"dmsg_servers,omitempty"`
 }
 
 // New constructs a new API instance.
@@ -74,6 +76,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 		store:                       s,
 		startedAt:                   time.Now(),
 		dmsgAddr:                    dmsgAddr,
+		DmsgServers:                 []string{},
 	}
 
 	r := chi.NewRouter()

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -205,9 +205,10 @@ func (api *API) deregisterTransport(w http.ResponseWriter, r *http.Request) {
 func (api *API) health(w http.ResponseWriter, r *http.Request) {
 	info := buildinfo.Get()
 	api.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
-		BuildInfo: info,
-		StartedAt: api.startedAt,
-		DmsgAddr:  api.dmsgAddr,
+		BuildInfo:   info,
+		StartedAt:   api.startedAt,
+		DmsgAddr:    api.dmsgAddr,
+		DmsgServers: api.DmsgServers,
 	})
 }
 

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
@@ -472,6 +472,16 @@ func (ce *Client) AllEntries(ctx context.Context) (entries []string, err error) 
 	return entries, err
 }
 
+// ConnectedServersPK return keys of all connected dmsg servers
+func (ce *Client) ConnectedServersPK() []string {
+	sessions := ce.allClientSessions(ce.porter)
+	addrs := make([]string, len(sessions))
+	for i, s := range sessions {
+		addrs[i] = s.RemotePK().String()
+	}
+	return addrs
+}
+
 // ConnectionsSummary associates connected clients, and the servers that connect such clients.
 // Key: Client PK, Value: Slice of Server PKs
 type ConnectionsSummary map[cipher.PubKey][]cipher.PubKey

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,7 +455,7 @@ github.com/rs/cors
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.12-0.20231120175607-0b6d5135bbc5
+# github.com/skycoin/dmsg v1.3.12-0.20231130180155-65d707cd1b01
 ## explicit; go 1.18
 github.com/skycoin/dmsg/internal/servermetrics
 github.com/skycoin/dmsg/pkg/direct


### PR DESCRIPTION
Fix: #19 

Changes: 
- add `dmsg_servers` info to `/health` endpoint of AR, RF, and TPD
- update `dmsg` to develop

How to test:
- clone `skywire` at develop, and `skywire-services`, `skywire-ut`, `skycoin-service-discovery` and `dmsg` at related branch to this PR
- run integration test env by `make integration-env-build`
- check `/health` endpoints of services at:
  - http://dmsg-discovery:9090/health
  - http://transport-discovery:9091/health
  - http://route-finder:9092/health
  - http://address-resolver:9093/health
  - http://uptime-tracker:9096/health
  - http://service-discovery:9098/health

Note: `dmsg-discovery` needs 1 minute wait for test, at the beginning no `dmsg-server` available there.