### PR TITLE
remove node-visualizer from joint compilation of skywire-services

### DIFF
--- a/cmd/skywire-services/commands/root.go
+++ b/cmd/skywire-services/commands/root.go
@@ -14,7 +14,6 @@ import (
 	ar "github.com/skycoin/skywire-services/cmd/address-resolver/commands"
 	confbs "github.com/skycoin/skywire-services/cmd/config-bootstrapper/commands"
 	kg "github.com/skycoin/skywire-services/cmd/keys-gen/commands"
-	nv "github.com/skycoin/skywire-services/cmd/node-visualizer/commands"
 	rf "github.com/skycoin/skywire-services/cmd/route-finder/commands"
 	se "github.com/skycoin/skywire-services/cmd/sw-env/commands"
 	tpd "github.com/skycoin/skywire-services/cmd/transport-discovery/commands"
@@ -30,7 +29,6 @@ func init() {
 		rf.RootCmd,
 		confbs.RootCmd,
 		kg.RootCmd,
-		nv.RootCmd,
 		se.RootCmd,
 		ut.RootCmd,
 	)
@@ -40,7 +38,6 @@ func init() {
 	rf.RootCmd.Use = "rf"
 	confbs.RootCmd.Use = "confbs"
 	kg.RootCmd.Use = "kg"
-	nv.RootCmd.Use = "nv"
 	se.RootCmd.Use = "se"
 	ut.RootCmd.Use = "ut"
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/2a5259e0-43fc-44d0-b558-55d126efd132)
the flags on the top level menu are not supposed to be there. i'm unsure why they appear, but they are related to the glog import which is an indirect import of node-visualizer. I'm not aware that the node-visualizer is actually used when it's in the joint compilation ; I'm unaware if it is actually deployed, currently, but I believe it isn't. this PR simply removes it from the joint compilation of skywire-services